### PR TITLE
Remove Nouvel OT button from header

### DIFF
--- a/GMAO_web.html
+++ b/GMAO_web.html
@@ -174,7 +174,6 @@
       <div class="header-actions">
         <button class="btn" id="themeToggle" type="button" onclick="toggleTheme()" title="Basculer le thème" aria-pressed="false">🌙 Mode sombre</button>
         <button class="btn primary" onclick="openModal('diModal')">➕ Demande d’intervention</button>
-        <button class="btn primary" onclick="openModal('otModal')">➕ Nouvel OT</button>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- remove the "Nouvel OT" action button from the header so only the intervention button remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91d447fac8330b23ba5f80cf7447a