### PR TITLE
Remove unused dashboard widgets

### DIFF
--- a/GMAO_web.html
+++ b/GMAO_web.html
@@ -403,8 +403,6 @@
         <div class="kpis">
           <div class="card"><div class="card-header"><h3>OT Ouverts</h3><span class="tag warn">+3 cette semaine</span></div><div class="value">18</div></div>
           <div class="card"><div class="card-header"><h3>Taux préventif réalisé</h3><span class="tag ok">Objectif ≥ 80%</span></div><div class="value">86%</div></div>
-          <div class="card"><div class="card-header"><h3>Temps moyen de résolution</h3><span class="tag">30 derniers jours</span></div><div class="value">7h45</div></div>
-          <div class="card"><div class="card-header"><h3>Coût maintenance mensuel</h3><span class="tag">Budget: 18 k€</span></div><div class="value">14,6 k€</div></div>
         </div>
 
         <div class="dashboard-layout">
@@ -430,63 +428,9 @@
                 </table>
               </div>
             </div>
-
-            <div class="card">
-              <div class="card-header"><h3>Activité du jour</h3><span class="chip">Mise à jour 14h35</span></div>
-              <div class="timeline" role="list">
-                <div class="timeline-item" role="listitem">
-                  <span class="timeline-time">08:45</span>
-                  <div class="timeline-content">
-                    <div class="timeline-title">DI #452 – Presse hydraulique</div>
-                    <div class="timeline-meta"><span class="status-badge bad">P1</span><span>Déclarée par J. Martin</span></div>
-                  </div>
-                </div>
-                <div class="timeline-item" role="listitem">
-                  <span class="timeline-time">10:20</span>
-                  <div class="timeline-content">
-                    <div class="timeline-title">OT-1025 passé en intervention</div>
-                    <div class="timeline-meta"><span class="status-badge warn">En cours</span><span>Technicien: L. Durand</span></div>
-                  </div>
-                </div>
-                <div class="timeline-item" role="listitem">
-                  <span class="timeline-time">13:05</span>
-                  <div class="timeline-content">
-                    <div class="timeline-title">Réception pièces Courroie HTD</div>
-                    <div class="timeline-meta"><span class="status-badge info">Stock</span><span>Magasin C3</span></div>
-                  </div>
-                </div>
-                <div class="timeline-item" role="listitem">
-                  <span class="timeline-time">15:30</span>
-                  <div class="timeline-content">
-                    <div class="timeline-title">Validation OT-1017 – Laveuse</div>
-                    <div class="timeline-meta"><span class="status-badge ok">Clôturé</span><span>Temps passé: 2h10</span></div>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
 
           <div class="stack">
-            <div class="card">
-              <div class="card-header"><h3>Alertes critiques</h3><span class="tag bad">2 urgences</span></div>
-              <div class="alert-list">
-                <div class="alert-item">
-                  <div>
-                    <div class="alert-machine">Compresseur KAESER</div>
-                    <div class="alert-meta"><span class="status-badge bad">P1</span><span>Pression instable</span></div>
-                  </div>
-                  <button class="btn" onclick="navigateToSection('interventions')">Voir OT</button>
-                </div>
-                <div class="alert-item">
-                  <div>
-                    <div class="alert-machine">Presse 250T – Zone Nord</div>
-                    <div class="alert-meta"><span class="status-badge warn">P2</span><span>Remontée DI #452</span></div>
-                  </div>
-                  <button class="btn" onclick="openModal('diModal')">Traiter</button>
-                </div>
-              </div>
-            </div>
-
             <div class="card">
               <div class="card-header"><h3>Préventif à venir</h3><span class="tag">7 jours</span></div>
               <div class="mini-bars">
@@ -503,24 +447,6 @@
                   <div class="progress"><span style="width:92%"></span></div>
                 </div>
               </div>
-            </div>
-
-            <div class="card">
-              <div class="card-header"><h3>Consommation pièces</h3><span class="tag">30 derniers jours</span></div>
-              <ul class="mini-bars" aria-label="Consommation de pièces">
-                <li>
-                  <div class="bar-meta"><span>Cartouche filtre CF-45</span><span>12 u.</span></div>
-                  <div class="bar"><span style="width:70%"></span></div>
-                </li>
-                <li>
-                  <div class="bar-meta"><span>Courroie HTD-560</span><span>7 u.</span></div>
-                  <div class="bar"><span style="width:50%"></span></div>
-                </li>
-                <li>
-                  <div class="bar-meta"><span>Graisse SKF-G1</span><span>18 u.</span></div>
-                  <div class="bar"><span style="width:82%"></span></div>
-                </li>
-              </ul>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove obsolete KPI and widget cards from the dashboard section of GMAO_web.html to match current requirements

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9330a31b4833092cc1b845da37994