### PR TITLE
Assure un fond sombre aux listes déroulantes en mode sombre

### DIFF
--- a/GMAO_web00.html
+++ b/GMAO_web00.html
@@ -111,7 +111,7 @@
     .toolbar .input, .toolbar select{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;color:var(--ink)}
     :root[data-theme="light"] .toolbar .input,
     :root[data-theme="light"] .toolbar select{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
-    select option{background:var(--panel);color:var(--ink)}
+    select option, select optgroup{background:var(--panel);color:var(--ink)}
     :root[data-theme="light"] select option{background:rgba(226,232,240,.95);color:var(--ink)}
 
     /* Parc machines */

--- a/GMAO_web250908.html
+++ b/GMAO_web250908.html
@@ -103,6 +103,7 @@
     .toolbar .input, .toolbar select{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;color:var(--ink)}
     :root[data-theme="light"] .toolbar .input,
     :root[data-theme="light"] .toolbar select{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
+    select option, select optgroup{background:var(--panel);color:var(--ink)}
 
     /* modal */
     .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);padding:24px}

--- a/preview/page web base v0.html
+++ b/preview/page web base v0.html
@@ -101,6 +101,7 @@
     .toolbar .input, .toolbar select{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;color:var(--ink)}
     :root[data-theme="light"] .toolbar .input,
     :root[data-theme="light"] .toolbar select{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
+    select option, select optgroup{background:var(--panel);color:var(--ink)}
 
     /* modal */
     .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);padding:24px}

--- a/save_page_html/GMAO_web_V0.html
+++ b/save_page_html/GMAO_web_V0.html
@@ -101,6 +101,7 @@
     .toolbar .input, .toolbar select{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;color:var(--ink)}
     :root[data-theme="light"] .toolbar .input,
     :root[data-theme="light"] .toolbar select{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
+    select option, select optgroup{background:var(--panel);color:var(--ink)}
 
     /* modal */
     .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);padding:24px}


### PR DESCRIPTION
## Summary
- applique une couleur de fond sombre et un contraste lisible aux options des listes déroulantes
- aligne la règle CSS sur l’ensemble des variantes de la maquette HTML

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d939e05db4833097ee2bb0c5c1e90a