### PR TITLE
Adjust toolbar select styling for dark theme

### DIFF
--- a/GMAO_web250908.html
+++ b/GMAO_web250908.html
@@ -101,8 +101,11 @@
 
     .toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:12px 0}
     .toolbar .input, .toolbar select{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;color:var(--ink)}
+    :root:not([data-theme="light"]) .toolbar select{background:var(--panel);border:1px solid rgba(255,255,255,.14)}
     :root[data-theme="light"] .toolbar .input,
     :root[data-theme="light"] .toolbar select{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
+    .toolbar select option{background:var(--panel);color:var(--ink)}
+    :root[data-theme="light"] .toolbar select option{background:rgba(226,232,240,.95);color:var(--ink)}
 
     /* modal */
     .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);padding:24px}


### PR DESCRIPTION
## Summary
- ensure toolbar select inputs use a panel-colored background in dark mode
- align toolbar select option colors with existing field option theming for both themes

## Testing
- manual

------
https://chatgpt.com/codex/tasks/task_e_68d93c0b77488330982ff7785efb14e1