### PR TITLE
Add attachment uploads and camera capture to intervention request modal

### DIFF
--- a/GMAO_web251003.html
+++ b/GMAO_web251003.html
@@ -35,6 +35,7 @@
       --shadow:0 12px 28px rgba(15,23,42,.12), 0 1px 0 rgba(15,23,42,.04) inset;
     }
     *{box-sizing:border-box}
+    [hidden]{display:none!important}
     html,body{height:100%}
     body{margin:0;background:radial-gradient(1200px 600px at 80% -10%,rgba(167,139,250,.15),transparent),
                           radial-gradient(900px 500px at -20% 10%,rgba(34,211,238,.12),transparent),
@@ -129,6 +130,22 @@
     :root[data-theme="light"] .field textarea{background:rgba(226,232,240,.6);border:1px solid rgba(148,163,184,.4)}
     :root[data-theme="light"] .field select option{background:rgba(226,232,240,.95);color:var(--ink)}
     .actions{display:flex;gap:8px;justify-content:flex-end;padding:0 16px 16px}
+
+    .attachments .attachment-actions{display:flex;flex-wrap:wrap;gap:8px}
+    .attachment-list{list-style:none;margin:8px 0 0;padding:0;display:grid;gap:6px}
+    .attachment-item{display:flex;align-items:center;justify-content:space-between;gap:12px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:8px 10px;font-size:13px}
+    :root[data-theme="light"] .attachment-item{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
+    .attachment-info{display:flex;flex-direction:column;gap:2px}
+    .attachment-name{font-weight:600}
+    .attachment-meta{font-size:12px;color:var(--ink-dim)}
+    .attachment-remove{background:transparent;border:0;color:var(--ink-dim);cursor:pointer;padding:4px;border-radius:8px;line-height:1;font-size:16px}
+    .attachment-remove:hover{color:var(--bad);background:rgba(239,68,68,.12)}
+    :root[data-theme="light"] .attachment-remove:hover{background:rgba(220,38,38,.12)}
+    .attachment-empty{font-size:12px;color:var(--ink-dim)}
+    .camera-preview{margin-top:12px;display:flex;flex-direction:column;gap:12px;background:rgba(15,23,42,.6);border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:12px}
+    :root[data-theme="light"] .camera-preview{background:rgba(226,232,240,.6);border:1px solid rgba(148,163,184,.4)}
+    .camera-preview video{width:100%;max-height:240px;border-radius:12px;background:black}
+    .camera-actions{display:flex;flex-wrap:wrap;gap:8px}
 
     /* chips */
     .chip{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.04);padding:6px 10px;border-radius:999px;font-size:12px}
@@ -566,6 +583,22 @@
             <label>Travaux à effectuer</label>
             <textarea rows="3" placeholder="Décrire les travaux demandés…"></textarea>
           </div>
+          <div class="field attachments" style="grid-column:1/-1">
+            <label>Pièces jointes</label>
+            <div class="attachment-actions">
+              <input id="diAttachmentInput" type="file" accept="image/*,.pdf,.doc,.docx,.txt,.xlsx,.xls,.ppt,.pptx" multiple hidden>
+              <button type="button" class="btn" id="diUploadButton">📎 Ajouter un fichier</button>
+              <button type="button" class="btn" id="diCameraButton" aria-expanded="false">📷 Prendre une photo</button>
+            </div>
+            <ul id="diAttachmentList" class="attachment-list"></ul>
+            <div class="camera-preview" id="diCameraPreview" hidden>
+              <video id="diCameraVideo" autoplay playsinline></video>
+              <div class="camera-actions">
+                <button type="button" class="btn primary" id="diCaptureBtn">📸 Capturer</button>
+                <button type="button" class="btn" id="diCloseCameraBtn">✖️ Fermer la caméra</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div class="actions">
@@ -692,6 +725,8 @@
     let activeModal = null;
     let lastFocusedElement = null;
     let currentInterventionRow = null;
+    let diAttachments = [];
+    let diCameraStream = null;
 
     function switchSection(e){
       e.preventDefault();
@@ -748,6 +783,8 @@
       modal.setAttribute('aria-hidden','true');
       if(id === 'interventionModal'){
         currentInterventionRow = null;
+      }else if(id === 'diModal'){
+        resetDemandModal();
       }
       if(activeModal === modal) activeModal = null;
       if(!document.querySelector('.modal.open')){
@@ -763,6 +800,140 @@
       if(activeModal){
         closeModal(activeModal.id);
       }
+    }
+
+    function addAttachments(files){
+      if(!files || !files.length) return;
+      diAttachments = diAttachments.concat(files);
+      renderAttachments();
+    }
+
+    function renderAttachments(){
+      const list = document.getElementById('diAttachmentList');
+      if(!list) return;
+      list.innerHTML = '';
+      if(!diAttachments.length){
+        const empty = document.createElement('li');
+        empty.className = 'attachment-empty';
+        empty.textContent = 'Aucune pièce jointe pour le moment.';
+        list.appendChild(empty);
+        return;
+      }
+      diAttachments.forEach((file,index)=>{
+        const li = document.createElement('li');
+        li.className = 'attachment-item';
+        const info = document.createElement('div');
+        info.className = 'attachment-info';
+        const name = document.createElement('span');
+        name.className = 'attachment-name';
+        name.textContent = file.name || `Photo ${index+1}.jpg`;
+        info.appendChild(name);
+        if(file.size){
+          const meta = document.createElement('span');
+          meta.className = 'attachment-meta';
+          const sizeKB = Math.max(1, Math.round(file.size/1024));
+          meta.textContent = `${sizeKB} Ko`;
+          info.appendChild(meta);
+        }
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'attachment-remove';
+        remove.setAttribute('data-remove-index', index);
+        remove.setAttribute('aria-label', `Retirer ${name.textContent}`);
+        remove.textContent = '✖️';
+        li.appendChild(info);
+        li.appendChild(remove);
+        list.appendChild(li);
+      });
+    }
+
+    function removeAttachment(index){
+      if(index<0 || index>=diAttachments.length) return;
+      diAttachments.splice(index,1);
+      renderAttachments();
+    }
+
+    async function openCamera(){
+      const preview = document.getElementById('diCameraPreview');
+      const video = document.getElementById('diCameraVideo');
+      const toggleBtn = document.getElementById('diCameraButton');
+      if(!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia){
+        alert('La capture depuis la caméra n’est pas supportée sur cet appareil.');
+        return;
+      }
+      try{
+        diCameraStream = await navigator.mediaDevices.getUserMedia({video:true});
+        if(video){
+          video.srcObject = diCameraStream;
+        }
+        if(preview){
+          preview.hidden = false;
+        }
+        if(toggleBtn){
+          toggleBtn.setAttribute('aria-expanded','true');
+          toggleBtn.textContent = '📷 Fermer la caméra';
+        }
+      }catch(err){
+        console.error('Impossible d’ouvrir la caméra', err);
+        alert('Impossible d’accéder à la caméra. Vérifiez les autorisations.');
+      }
+    }
+
+    function closeCamera(){
+      const preview = document.getElementById('diCameraPreview');
+      const video = document.getElementById('diCameraVideo');
+      const toggleBtn = document.getElementById('diCameraButton');
+      if(diCameraStream){
+        diCameraStream.getTracks().forEach(track=>track.stop());
+        diCameraStream = null;
+      }
+      if(video){
+        video.srcObject = null;
+      }
+      if(preview){
+        preview.hidden = true;
+      }
+      if(toggleBtn){
+        toggleBtn.setAttribute('aria-expanded','false');
+        toggleBtn.textContent = '📷 Prendre une photo';
+      }
+    }
+
+    function capturePhoto(){
+      const video = document.getElementById('diCameraVideo');
+      if(!video || !diCameraStream || video.readyState < 2){
+        return;
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if(!ctx){
+        return;
+      }
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(blob=>{
+        if(!blob) return;
+        const timestamp = new Date().toISOString().replace(/[:.]/g,'-');
+        let file;
+        try{
+          file = new File([blob], `photo-${timestamp}.jpg`, {type:'image/jpeg'});
+        }catch(_e){
+          file = blob;
+          file.name = `photo-${timestamp}.jpg`;
+        }
+        addAttachments([file]);
+      }, 'image/jpeg', 0.92);
+    }
+
+    function resetDemandModal(){
+      diAttachments = [];
+      const input = document.getElementById('diAttachmentInput');
+      if(input){
+        input.value = '';
+      }
+      renderAttachments();
+      closeCamera();
     }
 
     // Simple global filter across visible table bodies
@@ -899,6 +1070,63 @@
       });
 
       setupInterventionRows();
+
+      const attachmentInput = document.getElementById('diAttachmentInput');
+      const uploadButton = document.getElementById('diUploadButton');
+      const attachmentList = document.getElementById('diAttachmentList');
+      const cameraButton = document.getElementById('diCameraButton');
+      const captureButton = document.getElementById('diCaptureBtn');
+      const closeCameraBtn = document.getElementById('diCloseCameraBtn');
+
+      if(uploadButton && attachmentInput){
+        uploadButton.addEventListener('click', ()=>attachmentInput.click());
+      }
+
+      if(attachmentInput){
+        attachmentInput.addEventListener('change', evt=>{
+          const files = Array.from(evt.target.files || []);
+          addAttachments(files);
+          attachmentInput.value = '';
+        });
+      }
+
+      if(attachmentList){
+        attachmentList.addEventListener('click', evt=>{
+          const btn = evt.target.closest('button[data-remove-index]');
+          if(btn){
+            evt.preventDefault();
+            const index = Number(btn.getAttribute('data-remove-index'));
+            removeAttachment(index);
+          }
+        });
+      }
+
+      if(cameraButton){
+        cameraButton.addEventListener('click', evt=>{
+          evt.preventDefault();
+          if(diCameraStream){
+            closeCamera();
+          }else{
+            openCamera();
+          }
+        });
+      }
+
+      if(captureButton){
+        captureButton.addEventListener('click', evt=>{
+          evt.preventDefault();
+          capturePhoto();
+        });
+      }
+
+      if(closeCameraBtn){
+        closeCameraBtn.addEventListener('click', evt=>{
+          evt.preventDefault();
+          closeCamera();
+        });
+      }
+
+      renderAttachments();
 
       document.addEventListener('keydown', evt=>{
         if(evt.key === 'Escape' && activeModal){


### PR DESCRIPTION
## Summary
- add styled attachment controls to the intervention request modal, including file uploads and live camera capture
- manage attachment list rendering with removal actions and reset when the modal closes
- introduce camera preview handling with capture support and graceful fallback messaging

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68dff74289bc83309e85c3eb7ebfc536