### PR TITLE
Add editing workflows to key dashboard sections

### DIFF
--- a/GMAO_web251003.html
+++ b/GMAO_web251003.html
@@ -389,7 +389,8 @@
             <option>Tornos</option>
             <option>Kaeser</option>
           </select>
-          <button class="btn" onclick="openModal('equipModal')">➕ Ajouter équipement</button>
+          <button class="btn" type="button" onclick="prepareEquipmentModal('create')">➕ Ajouter équipement</button>
+          <button class="btn" type="button" onclick="startParcEdit()">✏️ Modifier</button>
         </div>
         <table aria-label="Parc">
           <thead><tr><th>Zone</th><th>Machine</th><th>Fabricant</th><th>Modèle</th><th>Numéro série</th><th>Année</th></tr></thead>
@@ -530,6 +531,7 @@
             <option value="used">Utilisée</option>
           </select>
           <button class="btn" type="button" onclick="openSparePartModal('pieces')">➕ Ajouter une pièce</button>
+          <button class="btn" type="button" onclick="startSparePartEdit()">✏️ Modifier</button>
         </div>
         <table aria-label="Pièces détachées">
           <thead>
@@ -548,7 +550,8 @@
             <option>Mensuel</option>
             <option>Trimestriel</option>
           </select>
-          <button class="btn" onclick="openModal('planModal')">⚙️ Générer OT préventifs</button>
+          <button class="btn" type="button" onclick="openModal('planModal')">⚙️ Générer OT préventifs</button>
+          <button class="btn" type="button" onclick="startPreventifEdit()">✏️ Modifier</button>
         </div>
         <table aria-label="Plan préventif">
           <thead><tr><th>Plan</th><th>Machine</th><th>Périodicité</th><th>Dernier</th><th>Prochain</th><th>État</th></tr></thead>
@@ -594,7 +597,8 @@
       <section id="contacts" class="section" aria-label="Contacts">
         <div class="toolbar">
           <input class="input" placeholder="Rechercher fournisseur/intervenant…" oninput="filterTable('tblContacts', this.value, [0,1,2,3])">
-          <button class="btn" onclick="openModal('contactModal')">➕ Nouveau contact</button>
+          <button class="btn" type="button" onclick="openContactForm('create')">➕ Nouveau contact</button>
+          <button class="btn" type="button" onclick="startContactEdit()">✏️ Modifier</button>
         </div>
         <table aria-label="Contacts">
           <thead><tr><th>Entreprise</th><th>Activité</th><th>Contact</th><th>Email</th><th>Téléphone</th></tr></thead>
@@ -875,6 +879,31 @@
     </div>
   </div>
 
+  <div class="modal" id="preventifEditModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Modifier un plan préventif">
+    <div class="sheet">
+      <header>
+        <div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Modifier un plan préventif</h1></div>
+      </header>
+      <div class="content">
+        <form id="preventifForm">
+          <div class="grid">
+            <div class="field"><label for="preventifPlanInput">Plan</label><input id="preventifPlanInput" type="text" placeholder="Identifiant du plan"></div>
+            <div class="field"><label for="preventifMachineInput">Machine</label><input id="preventifMachineInput" type="text" placeholder="Machine concernée"></div>
+            <div class="field"><label for="preventifPeriodiciteInput">Périodicité</label><select id="preventifPeriodiciteInput"><option value="">Sélectionner…</option><option>Hebdo</option><option>Mensuel</option><option>Trimestriel</option><option>Semestriel</option><option>Annuel</option></select></div>
+            <div class="field"><label for="preventifDernierInput">Dernière réalisation</label><input id="preventifDernierInput" type="date"></div>
+            <div class="field"><label for="preventifProchainInput">Prochaine échéance</label><input id="preventifProchainInput" type="date"></div>
+            <div class="field"><label for="preventifEtatLabelInput">État (libellé)</label><input id="preventifEtatLabelInput" type="text" placeholder="Ex. À l'heure"></div>
+            <div class="field"><label for="preventifEtatClassInput">État (couleur)</label><select id="preventifEtatClassInput"><option value="">Neutre</option><option value="ok">OK</option><option value="warn">Attention</option><option value="bad">Critique</option></select></div>
+          </div>
+        </form>
+      </div>
+      <div class="actions">
+        <button class="btn" type="button" onclick="closeModal('preventifEditModal')">Annuler</button>
+        <button class="btn primary" type="submit" form="preventifForm">Mettre à jour</button>
+      </div>
+    </div>
+  </div>
+
   <div class="modal" id="contactDetailModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Détails du contact">
     <div class="sheet">
       <header>
@@ -898,7 +927,7 @@
   <div class="modal" id="pieceModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Ajouter une pièce détachée">
     <div class="sheet">
       <header>
-        <div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Nouvelle pièce détachée</h1></div>
+        <div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1 id="pieceModalTitle">Nouvelle pièce détachée</h1></div>
       </header>
       <div class="content">
         <form id="pieceForm">
@@ -917,13 +946,56 @@
       </div>
       <div class="actions">
         <button class="btn" type="button" onclick="closeModal('pieceModal')">Annuler</button>
-        <button class="btn primary" type="submit" form="pieceForm">Enregistrer</button>
+        <button class="btn primary" id="pieceSaveBtn" type="submit" form="pieceForm">Enregistrer</button>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="equipModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Ajouter un équipement"><div class="sheet"><header><div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Ajouter équipement</h1></div></header><div class="content"><div class="grid"><div class="field"><label for="equip-zone">Zone</label><input id="equip-zone" type="text" placeholder="Zone de l'équipement"></div><div class="field"><label for="equip-machine">Machine</label><input id="equip-machine" type="text" placeholder="Nom de la machine"></div><div class="field"><label for="equip-fabricant">Fabricant</label><input id="equip-fabricant" type="text" placeholder="Fabricant"></div><div class="field"><label for="equip-modele">Modèle</label><input id="equip-modele" type="text" placeholder="Référence ou modèle"></div><div class="field"><label for="equip-serial">Numéro de série</label><input id="equip-serial" type="text" placeholder="Numéro de série"></div><div class="field"><label for="equip-annee">Année</label><input id="equip-annee" type="number" inputmode="numeric" min="1900" max="2100" placeholder="Année de mise en service"></div></div></div><div class="actions"><button class="btn" onclick="closeModal('equipModal')">Fermer</button><button class="btn primary" onclick="closeModal('equipModal')">Enregistrer</button></div></div></div>
-  <div class="modal" id="contactModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Créer un contact"><div class="sheet"><header><div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Nouveau contact</h1></div></header><div class="content"><div class="grid"><div class="field"><label>Entreprise</label><input></div><div class="field"><label>Activité</label><input></div><div class="field"><label>Contact</label><input></div><div class="field"><label>Email</label><input type="email"></div><div class="field"><label>Téléphone</label><input></div></div></div><div class="actions"><button class="btn" onclick="closeModal('contactModal')">Fermer</button><button class="btn primary" onclick="closeModal('contactModal')">Enregistrer</button></div></div></div>
+  <div class="modal" id="equipModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Ajouter ou modifier un équipement">
+    <div class="sheet">
+      <header>
+        <div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1 id="equipModalTitle">Ajouter équipement</h1></div>
+      </header>
+      <div class="content">
+        <form id="equipForm">
+          <div class="grid">
+            <div class="field"><label for="equip-zone">Zone</label><input id="equip-zone" type="text" placeholder="Zone de l'équipement"></div>
+            <div class="field"><label for="equip-machine">Machine</label><input id="equip-machine" type="text" placeholder="Nom de la machine"></div>
+            <div class="field"><label for="equip-fabricant">Fabricant</label><input id="equip-fabricant" type="text" placeholder="Fabricant"></div>
+            <div class="field"><label for="equip-modele">Modèle</label><input id="equip-modele" type="text" placeholder="Référence ou modèle"></div>
+            <div class="field"><label for="equip-serial">Numéro de série</label><input id="equip-serial" type="text" placeholder="Numéro de série"></div>
+            <div class="field"><label for="equip-annee">Année</label><input id="equip-annee" type="number" inputmode="numeric" min="1900" max="2100" placeholder="Année de mise en service"></div>
+          </div>
+        </form>
+      </div>
+      <div class="actions">
+        <button class="btn" type="button" onclick="closeModal('equipModal')">Annuler</button>
+        <button class="btn primary" id="equipSaveBtn" type="submit" form="equipForm">Enregistrer</button>
+      </div>
+    </div>
+  </div>
+  <div class="modal" id="contactModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Créer ou modifier un contact">
+    <div class="sheet">
+      <header>
+        <div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1 id="contactModalTitle">Nouveau contact</h1></div>
+      </header>
+      <div class="content">
+        <form id="contactForm">
+          <div class="grid">
+            <div class="field"><label for="contactEntreprise">Entreprise</label><input id="contactEntreprise" type="text" placeholder="Nom de l'entreprise"></div>
+            <div class="field"><label for="contactActivite">Activité</label><input id="contactActivite" type="text" placeholder="Secteur ou spécialité"></div>
+            <div class="field"><label for="contactNom">Contact</label><input id="contactNom" type="text" placeholder="Nom du contact"></div>
+            <div class="field"><label for="contactEmail">Email</label><input id="contactEmail" type="email" placeholder="adresse@email.tld"></div>
+            <div class="field"><label for="contactTelephone">Téléphone</label><input id="contactTelephone" type="tel" placeholder="Numéro de téléphone"></div>
+          </div>
+        </form>
+      </div>
+      <div class="actions">
+        <button class="btn" type="button" onclick="closeModal('contactModal')">Annuler</button>
+        <button class="btn primary" id="contactSaveBtn" type="submit" form="contactForm">Enregistrer</button>
+      </div>
+    </div>
+  </div>
   <div class="modal" id="planModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Générer des OT préventifs"><div class="sheet"><header><div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Générer OT préventifs</h1></div></header><div class="content"><p>Sélectionner l'horizon de planification et la périodicité.</p><div class="grid"><div class="field"><label>Horizon (jours)</label><input type="number" value="30"></div><div class="field"><label>Inclure retard</label><select><option>Oui</option><option>Non</option></select></div></div></div><div class="actions"><button class="btn" onclick="closeModal('planModal')">Fermer</button><button class="btn primary" onclick="closeModal('planModal')">Générer</button></div></div></div>
   <div class="modal" id="reportModal" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Exporter les données"><div class="sheet"><header><div class="brand"><div class="logo" style="width:28px;height:28px"></div><h1>Export rapide</h1></div></header><div class="content"><p>Ce prototype exportera un CSV fictif. À connecter à votre backend plus tard.</p></div><div class="actions"><button class="btn" onclick="closeModal('reportModal')">Fermer</button><button class="btn primary" onclick="fakeExport()">Exporter CSV</button></div></div></div>
 
@@ -970,6 +1042,11 @@
     let activeModal = null;
     let lastFocusedElement = null;
     let currentInterventionRow = null;
+    let currentParcRow = null;
+    let equipModalMode = 'create';
+    let currentPreventifRow = null;
+    let currentContactRow = null;
+    let contactModalMode = 'create';
     const ATTACHMENT_CONTEXTS = {
       di:{
         attachments:[],
@@ -1005,9 +1082,12 @@
       used:{label:'Utilisée', tagClass:'ok'}
     };
     let spareParts = [
-      {reference:'RB-0001', designation:'Kit roulements broche', ot:'OT-1024', machine:'DMU 70', status:'ordered', quantity:1, date:'2025-09-18', note:'Commande urgente fournisseur AirTech'},
-      {reference:'FL-0450', designation:'Filtre air KAESER', ot:'OT-1026', machine:'Compresseur KAESER', status:'used', quantity:1, date:'2025-09-22', note:'Installé lors de l’intervention'}
+      {id:1, reference:'RB-0001', designation:'Kit roulements broche', ot:'OT-1024', machine:'DMU 70', status:'ordered', quantity:1, date:'2025-09-18', note:'Commande urgente fournisseur AirTech'},
+      {id:2, reference:'FL-0450', designation:'Filtre air KAESER', ot:'OT-1026', machine:'Compresseur KAESER', status:'used', quantity:1, date:'2025-09-22', note:'Installé lors de l’intervention'}
     ];
+    let sparePartIdCounter = spareParts.length + 1;
+    let sparePartModalMode = 'create';
+    let currentSparePartId = null;
     let sparePartModalContext = {source:'pieces', defaults:{}};
 
     function switchSection(e){
@@ -1071,6 +1151,12 @@
         resetDemandModal();
       }else if(id === 'pieceModal'){
         resetSparePartModal();
+      }else if(id === 'equipModal'){
+        resetEquipmentForm();
+      }else if(id === 'contactModal'){
+        resetContactForm();
+      }else if(id === 'preventifEditModal'){
+        resetPreventifForm();
       }
       if(activeModal === modal) activeModal = null;
       if(!document.querySelector('.modal.open')){
@@ -1398,6 +1484,7 @@
         }
         const statusMeta = getSparePartStatusMeta(part.status);
         const displayDate = formatDisplayDate(part.date);
+        tr.dataset.partId = part.id != null ? String(part.id) : '';
         tr.dataset.reference = part.reference || '';
         tr.dataset.designation = part.designation || '';
         tr.dataset.ot = part.ot || '';
@@ -1477,19 +1564,35 @@
     }
 
     function resetSparePartModal(){
+      sparePartModalMode = 'create';
+      currentSparePartId = null;
       sparePartModalContext = {source:'pieces', defaults:{}};
       const form = document.getElementById('pieceForm');
       if(form) form.reset();
+      const title = document.getElementById('pieceModalTitle');
+      if(title) title.textContent = 'Nouvelle pièce détachée';
+      const saveBtn = document.getElementById('pieceSaveBtn');
+      if(saveBtn) saveBtn.textContent = 'Enregistrer';
       const info = document.getElementById('pieceContextInfo');
       if(info){
         info.textContent = 'Associer une pièce détachée au stock ou à une intervention.';
       }
     }
 
-    function openSparePartModal(source='pieces', defaults={}){
+    function openSparePartModal(source='pieces', defaults={}, options={}){
       sparePartModalContext = {source, defaults};
+      sparePartModalMode = options.mode || 'create';
+      currentSparePartId = options.partId ?? (options.mode === 'edit' && defaults.id != null ? defaults.id : null);
       const form = document.getElementById('pieceForm');
       if(form) form.reset();
+      const title = document.getElementById('pieceModalTitle');
+      if(title){
+        title.textContent = sparePartModalMode === 'edit' ? 'Modifier une pièce détachée' : 'Nouvelle pièce détachée';
+      }
+      const saveBtn = document.getElementById('pieceSaveBtn');
+      if(saveBtn){
+        saveBtn.textContent = sparePartModalMode === 'edit' ? 'Mettre à jour' : 'Enregistrer';
+      }
       const referenceInput = document.getElementById('pieceReference');
       const designationInput = document.getElementById('pieceDesignation');
       const otInput = document.getElementById('pieceOt');
@@ -1552,7 +1655,16 @@
         status = 'ordered';
       }
 
-      spareParts.push({reference, designation, ot, machine, status, quantity, date, note});
+      if(sparePartModalMode === 'edit' && currentSparePartId != null){
+        const part = spareParts.find(p=>p.id === currentSparePartId);
+        if(part){
+          Object.assign(part, {reference, designation, ot, machine, status, quantity, date, note});
+        }
+      }else{
+        const newPart = {id:sparePartIdCounter++, reference, designation, ot, machine, status, quantity, date, note};
+        spareParts.push(newPart);
+        currentSparePartId = newPart.id;
+      }
       renderSpareParts();
       const targetOt = currentInterventionRow ? (currentInterventionRow.dataset.ot || '') : (ot || sparePartModalContext.defaults.ot || '');
       if(targetOt){
@@ -1639,6 +1751,7 @@
     }
 
     function openParcDetail(row){
+      currentParcRow = row;
       const ds = row.dataset || {};
       setDetailText('parcDetailZone', ds.zone);
       setDetailText('parcDetailMachine', ds.machine);
@@ -1649,7 +1762,136 @@
       openModal('parcDetailModal');
     }
 
+    function resetEquipmentForm(){
+      equipModalMode = 'create';
+      const form = document.getElementById('equipForm');
+      if(form) form.reset();
+      const title = document.getElementById('equipModalTitle');
+      if(title) title.textContent = 'Ajouter équipement';
+      const saveBtn = document.getElementById('equipSaveBtn');
+      if(saveBtn) saveBtn.textContent = 'Enregistrer';
+    }
+
+    function prepareEquipmentModal(mode='create'){
+      const form = document.getElementById('equipForm');
+      if(!form) return;
+      if(mode === 'edit' && !currentParcRow){
+        alert('Sélectionnez un équipement dans le tableau pour le modifier.');
+        return;
+      }
+      equipModalMode = mode;
+      form.reset();
+      const zoneInput = document.getElementById('equip-zone');
+      const machineInput = document.getElementById('equip-machine');
+      const fabricantInput = document.getElementById('equip-fabricant');
+      const modeleInput = document.getElementById('equip-modele');
+      const serialInput = document.getElementById('equip-serial');
+      const anneeInput = document.getElementById('equip-annee');
+      const title = document.getElementById('equipModalTitle');
+      const saveBtn = document.getElementById('equipSaveBtn');
+
+      if(mode === 'edit' && currentParcRow){
+        const ds = currentParcRow.dataset;
+        if(zoneInput) zoneInput.value = ds.zone || '';
+        if(machineInput) machineInput.value = ds.machine || '';
+        if(fabricantInput) fabricantInput.value = ds.fabricant || '';
+        if(modeleInput) modeleInput.value = ds.modele || '';
+        if(serialInput) serialInput.value = ds.serie || '';
+        if(anneeInput) anneeInput.value = ds.annee || '';
+        if(title) title.textContent = 'Modifier équipement';
+        if(saveBtn) saveBtn.textContent = 'Mettre à jour';
+      }else{
+        if(title) title.textContent = 'Ajouter équipement';
+        if(saveBtn) saveBtn.textContent = 'Enregistrer';
+      }
+
+      openModal('equipModal');
+      if(machineInput){
+        requestAnimationFrame(()=>machineInput.focus({preventScroll:true}));
+      }
+    }
+
+    function startParcEdit(){
+      if(!currentParcRow){
+        alert('Sélectionnez un équipement dans le tableau pour le modifier.');
+        return;
+      }
+      if(document.getElementById('parcDetailModal')?.classList.contains('open')){
+        closeModal('parcDetailModal');
+      }
+      prepareEquipmentModal('edit');
+    }
+
+    function saveEquipment(){
+      const zone = (document.getElementById('equip-zone')?.value || '').trim();
+      const machine = (document.getElementById('equip-machine')?.value || '').trim();
+      const fabricant = (document.getElementById('equip-fabricant')?.value || '').trim();
+      const modele = (document.getElementById('equip-modele')?.value || '').trim();
+      const serie = (document.getElementById('equip-serial')?.value || '').trim();
+      const annee = (document.getElementById('equip-annee')?.value || '').trim();
+      const data = {zone, machine, fabricant, modele, serie, annee};
+
+      if(equipModalMode === 'edit' && currentParcRow){
+        Object.assign(currentParcRow.dataset, {
+          zone,
+          machine,
+          fabricant,
+          modele,
+          serie,
+          annee
+        });
+        const ariaLabelParts = [machine, modele].filter(Boolean).join(' ');
+        if(ariaLabelParts){
+          currentParcRow.setAttribute('aria-label', `Voir le détail de ${ariaLabelParts}`);
+        }else{
+          currentParcRow.removeAttribute('aria-label');
+        }
+        const cells = currentParcRow.cells;
+        if(cells[0]) cells[0].innerText = zone || '—';
+        if(cells[1]) cells[1].innerText = machine || '—';
+        if(cells[2]) cells[2].innerText = fabricant || '—';
+        if(cells[3]) cells[3].innerText = modele || '—';
+        if(cells[4]) cells[4].innerText = serie || '—';
+        if(cells[5]) cells[5].innerText = annee || '—';
+        if(document.getElementById('parcDetailModal')?.classList.contains('open')){
+          setDetailText('parcDetailZone', zone);
+          setDetailText('parcDetailMachine', machine);
+          setDetailText('parcDetailFabricant', fabricant);
+          setDetailText('parcDetailModele', modele);
+          setDetailText('parcDetailSerie', serie);
+          setDetailText('parcDetailAnnee', annee);
+        }
+      }else{
+        const tbody = document.getElementById('tblParc');
+        if(tbody){
+          const tr = document.createElement('tr');
+          tr.className = 'clickable';
+          tr.setAttribute('role','button');
+          tr.tabIndex = 0;
+          Object.assign(tr.dataset, data);
+          const ariaLabelParts = [machine, modele].filter(Boolean).join(' ');
+          if(ariaLabelParts){
+            tr.setAttribute('aria-label', `Voir le détail de ${ariaLabelParts}`);
+          }
+          const values = [zone, machine, fabricant, modele, serie, annee];
+          values.forEach(value=>{
+            const td = document.createElement('td');
+            td.textContent = value || '—';
+            tr.appendChild(td);
+          });
+          attachInteractiveRow(tr, openParcDetail);
+          tbody.appendChild(tr);
+          currentParcRow = tr;
+        }
+      }
+
+      closeModal('equipModal');
+    }
+
     function openSparePartDetail(row){
+      const idRaw = row?.dataset?.partId;
+      currentSparePartId = idRaw ? Number(idRaw) : null;
+      if(Number.isNaN(currentSparePartId)) currentSparePartId = null;
       const ds = row.dataset || {};
       const displayDate = ds.dateDisplay || formatDisplayDate(ds.date || '');
       setDetailText('pieceDetailReference', ds.reference);
@@ -1664,6 +1906,22 @@
       openModal('pieceDetailModal');
     }
 
+    function startSparePartEdit(){
+      if(currentSparePartId == null){
+        alert('Sélectionnez une pièce détachée dans le tableau pour la modifier.');
+        return;
+      }
+      const part = spareParts.find(p=>p.id === currentSparePartId);
+      if(!part){
+        alert('Pièce détachée introuvable.');
+        return;
+      }
+      if(document.getElementById('pieceDetailModal')?.classList.contains('open')){
+        closeModal('pieceDetailModal');
+      }
+      openSparePartModal('pieces', {...part}, {mode:'edit', partId: part.id});
+    }
+
     function setupPreventifRows(){
       document.querySelectorAll('#tblPrev tr.clickable').forEach(tr=>{
         attachInteractiveRow(tr, openPreventifDetail);
@@ -1671,6 +1929,7 @@
     }
 
     function openPreventifDetail(row){
+      currentPreventifRow = row;
       const ds = row.dataset || {};
       setDetailText('preventifDetailPlan', ds.plan);
       setDetailText('preventifDetailMachine', ds.machine);
@@ -1681,6 +1940,135 @@
       openModal('preventifDetailModal');
     }
 
+    function resetPreventifForm(){
+      const form = document.getElementById('preventifForm');
+      if(form) form.reset();
+    }
+
+    function startPreventifEdit(){
+      if(!currentPreventifRow){
+        alert('Sélectionnez un plan préventif dans le tableau pour le modifier.');
+        return;
+      }
+      resetPreventifForm();
+      const ds = currentPreventifRow.dataset || {};
+      const planInput = document.getElementById('preventifPlanInput');
+      const machineInput = document.getElementById('preventifMachineInput');
+      const periodiciteSelect = document.getElementById('preventifPeriodiciteInput');
+      const dernierInput = document.getElementById('preventifDernierInput');
+      const prochainInput = document.getElementById('preventifProchainInput');
+      const etatLabelInput = document.getElementById('preventifEtatLabelInput');
+      const etatClassSelect = document.getElementById('preventifEtatClassInput');
+
+      const toISO = value=>{
+        if(!value) return '';
+        if(/\d{4}-\d{2}-\d{2}/.test(value)) return value;
+        const parts = value.split('/');
+        if(parts.length === 3){
+          return `${parts[2]}-${parts[1].padStart(2,'0')}-${parts[0].padStart(2,'0')}`;
+        }
+        return '';
+      };
+
+      if(planInput) planInput.value = ds.plan || '';
+      if(machineInput) machineInput.value = ds.machine || '';
+      if(periodiciteSelect){
+        if(ds.periodicite){
+          const hasOption = Array.from(periodiciteSelect.options).some(opt=>opt.value === ds.periodicite);
+          if(!hasOption){
+            const opt = document.createElement('option');
+            opt.value = ds.periodicite;
+            opt.textContent = ds.periodicite;
+            periodiciteSelect.appendChild(opt);
+          }
+        }
+        periodiciteSelect.value = ds.periodicite || '';
+      }
+      if(dernierInput) dernierInput.value = ds.dernierIso || toISO(ds.dernier || '');
+      if(prochainInput) prochainInput.value = ds.prochainIso || toISO(ds.prochain || '');
+      if(etatLabelInput) etatLabelInput.value = ds.etat || '';
+      if(etatClassSelect){
+        if(ds.etatClass){
+          const hasClassOption = Array.from(etatClassSelect.options).some(opt=>opt.value === ds.etatClass);
+          if(!hasClassOption){
+            const opt = document.createElement('option');
+            opt.value = ds.etatClass;
+            opt.textContent = ds.etatClass;
+            etatClassSelect.appendChild(opt);
+          }
+        }
+        etatClassSelect.value = ds.etatClass || '';
+      }
+
+      if(document.getElementById('preventifDetailModal')?.classList.contains('open')){
+        closeModal('preventifDetailModal');
+      }
+      openModal('preventifEditModal');
+      if(planInput){
+        requestAnimationFrame(()=>planInput.focus({preventScroll:true}));
+      }
+    }
+
+    function savePreventifEdit(){
+      if(!currentPreventifRow){
+        closeModal('preventifEditModal');
+        return;
+      }
+      const plan = (document.getElementById('preventifPlanInput')?.value || '').trim();
+      const machine = (document.getElementById('preventifMachineInput')?.value || '').trim();
+      const periodicite = document.getElementById('preventifPeriodiciteInput')?.value || '';
+      const dernierIso = document.getElementById('preventifDernierInput')?.value || '';
+      const prochainIso = document.getElementById('preventifProchainInput')?.value || '';
+      const etatLabel = (document.getElementById('preventifEtatLabelInput')?.value || '').trim();
+      const etatClass = document.getElementById('preventifEtatClassInput')?.value || '';
+
+      const dernierDisplay = formatDisplayDate(dernierIso);
+      const prochainDisplay = formatDisplayDate(prochainIso);
+
+      Object.assign(currentPreventifRow.dataset, {
+        plan,
+        machine,
+        periodicite,
+        dernier: dernierDisplay === '—' ? '' : dernierDisplay,
+        dernierIso,
+        prochain: prochainDisplay === '—' ? '' : prochainDisplay,
+        prochainIso,
+        etat: etatLabel,
+        etatClass
+      });
+
+      if(plan){
+        currentPreventifRow.setAttribute('aria-label', `Voir le plan préventif ${plan}`);
+      }else{
+        currentPreventifRow.removeAttribute('aria-label');
+      }
+
+      const cells = currentPreventifRow.cells;
+      if(cells[0]) cells[0].innerText = plan || '—';
+      if(cells[1]) cells[1].innerText = machine || '—';
+      if(cells[2]) cells[2].innerText = periodicite || '—';
+      if(cells[3]) cells[3].innerText = dernierDisplay;
+      if(cells[4]) cells[4].innerText = prochainDisplay;
+      if(cells[5]){
+        cells[5].innerHTML = '';
+        const span = document.createElement('span');
+        span.className = ['status', etatClass].filter(Boolean).join(' ');
+        span.textContent = etatLabel || '—';
+        cells[5].appendChild(span);
+      }
+
+      if(document.getElementById('preventifDetailModal')?.classList.contains('open')){
+        setDetailText('preventifDetailPlan', plan);
+        setDetailText('preventifDetailMachine', machine);
+        setDetailText('preventifDetailPeriodicite', periodicite);
+        setDetailText('preventifDetailDernier', dernierDisplay === '—' ? '' : dernierDisplay);
+        setDetailText('preventifDetailProchain', prochainDisplay === '—' ? '' : prochainDisplay);
+        setDetailBadge('preventifDetailEtat', 'status', etatClass || '', etatLabel);
+      }
+
+      closeModal('preventifEditModal');
+    }
+
     function setupContactRows(){
       document.querySelectorAll('#tblContacts tr.clickable').forEach(tr=>{
         attachInteractiveRow(tr, openContactDetail);
@@ -1688,6 +2076,7 @@
     }
 
     function openContactDetail(row){
+      currentContactRow = row;
       const ds = row.dataset || {};
       setDetailText('contactDetailEntreprise', ds.entreprise);
       setDetailText('contactDetailActivite', ds.activite);
@@ -1695,6 +2084,127 @@
       setDetailText('contactDetailEmail', ds.email);
       setDetailText('contactDetailTelephone', ds.telephone);
       openModal('contactDetailModal');
+    }
+
+    function resetContactForm(){
+      contactModalMode = 'create';
+      const form = document.getElementById('contactForm');
+      if(form) form.reset();
+      const title = document.getElementById('contactModalTitle');
+      if(title) title.textContent = 'Nouveau contact';
+      const saveBtn = document.getElementById('contactSaveBtn');
+      if(saveBtn) saveBtn.textContent = 'Enregistrer';
+    }
+
+    function openContactForm(mode='create'){
+      const form = document.getElementById('contactForm');
+      if(!form) return;
+      if(mode === 'edit' && !currentContactRow){
+        alert('Sélectionnez un contact dans le tableau pour le modifier.');
+        return;
+      }
+      contactModalMode = mode;
+      form.reset();
+      const entrepriseInput = document.getElementById('contactEntreprise');
+      const activiteInput = document.getElementById('contactActivite');
+      const nomInput = document.getElementById('contactNom');
+      const emailInput = document.getElementById('contactEmail');
+      const telephoneInput = document.getElementById('contactTelephone');
+      const title = document.getElementById('contactModalTitle');
+      const saveBtn = document.getElementById('contactSaveBtn');
+
+      if(mode === 'edit' && currentContactRow){
+        const ds = currentContactRow.dataset;
+        if(entrepriseInput) entrepriseInput.value = ds.entreprise || '';
+        if(activiteInput) activiteInput.value = ds.activite || '';
+        if(nomInput) nomInput.value = ds.contact || '';
+        if(emailInput) emailInput.value = ds.email || '';
+        if(telephoneInput) telephoneInput.value = ds.telephone || '';
+        if(title) title.textContent = 'Modifier contact';
+        if(saveBtn) saveBtn.textContent = 'Mettre à jour';
+      }else{
+        if(title) title.textContent = 'Nouveau contact';
+        if(saveBtn) saveBtn.textContent = 'Enregistrer';
+      }
+
+      if(document.getElementById('contactDetailModal')?.classList.contains('open')){
+        closeModal('contactDetailModal');
+      }
+      openModal('contactModal');
+      if(entrepriseInput){
+        requestAnimationFrame(()=>entrepriseInput.focus({preventScroll:true}));
+      }
+    }
+
+    function startContactEdit(){
+      if(!currentContactRow){
+        alert('Sélectionnez un contact dans le tableau pour le modifier.');
+        return;
+      }
+      openContactForm('edit');
+    }
+
+    function saveContact(){
+      const entreprise = (document.getElementById('contactEntreprise')?.value || '').trim();
+      const activite = (document.getElementById('contactActivite')?.value || '').trim();
+      const contactNom = (document.getElementById('contactNom')?.value || '').trim();
+      const email = (document.getElementById('contactEmail')?.value || '').trim();
+      const telephone = (document.getElementById('contactTelephone')?.value || '').trim();
+
+      const data = {
+        entreprise,
+        activite,
+        contact: contactNom,
+        email,
+        telephone
+      };
+
+      if(contactModalMode === 'edit' && currentContactRow){
+        Object.assign(currentContactRow.dataset, data);
+        const cells = currentContactRow.cells;
+        if(cells[0]) cells[0].innerText = entreprise || '—';
+        if(cells[1]) cells[1].innerText = activite || '—';
+        if(cells[2]) cells[2].innerText = contactNom || '—';
+        if(cells[3]) cells[3].innerText = email || '—';
+        if(cells[4]) cells[4].innerText = telephone || '—';
+        const ariaLabelParts = [entreprise, contactNom].filter(Boolean).join(' – ');
+        if(ariaLabelParts){
+          currentContactRow.setAttribute('aria-label', `Voir le contact ${ariaLabelParts}`);
+        }else{
+          currentContactRow.removeAttribute('aria-label');
+        }
+        if(document.getElementById('contactDetailModal')?.classList.contains('open')){
+          setDetailText('contactDetailEntreprise', entreprise);
+          setDetailText('contactDetailActivite', activite);
+          setDetailText('contactDetailNom', contactNom);
+          setDetailText('contactDetailEmail', email);
+          setDetailText('contactDetailTelephone', telephone);
+        }
+      }else{
+        const tbody = document.getElementById('tblContacts');
+        if(tbody){
+          const tr = document.createElement('tr');
+          tr.className = 'clickable';
+          tr.setAttribute('role','button');
+          tr.tabIndex = 0;
+          Object.assign(tr.dataset, data);
+          const ariaLabelParts = [entreprise, contactNom].filter(Boolean).join(' – ');
+          if(ariaLabelParts){
+            tr.setAttribute('aria-label', `Voir le contact ${ariaLabelParts}`);
+          }
+          const values = [entreprise, activite, contactNom, email, telephone];
+          values.forEach(value=>{
+            const td = document.createElement('td');
+            td.textContent = value || '—';
+            tr.appendChild(td);
+          });
+          attachInteractiveRow(tr, openContactDetail);
+          tbody.appendChild(tr);
+          currentContactRow = tr;
+        }
+      }
+
+      closeModal('contactModal');
     }
 
     function openInterventionDetail(row){
@@ -1800,6 +2310,30 @@
         pieceForm.addEventListener('submit', evt=>{
           evt.preventDefault();
           saveSparePart();
+        });
+      }
+
+      const equipForm = document.getElementById('equipForm');
+      if(equipForm){
+        equipForm.addEventListener('submit', evt=>{
+          evt.preventDefault();
+          saveEquipment();
+        });
+      }
+
+      const contactForm = document.getElementById('contactForm');
+      if(contactForm){
+        contactForm.addEventListener('submit', evt=>{
+          evt.preventDefault();
+          saveContact();
+        });
+      }
+
+      const preventifForm = document.getElementById('preventifForm');
+      if(preventifForm){
+        preventifForm.addEventListener('submit', evt=>{
+          evt.preventDefault();
+          savePreventifEdit();
         });
       }
 


### PR DESCRIPTION
## Summary
- add edit actions to the parc machines, pièces détachées, préventif, and contacts toolbars
- enhance the equipment, spare parts, preventive plan, and contact modals to support modifying existing records
- implement JavaScript handlers to populate the edit forms and persist updates back into the tables

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e125d24ab08330bcab1faa0d98ce05