### PR TITLE
Remove Nouvel OT button from intervention tab

### DIFF
--- a/GMAO_web251003.html
+++ b/GMAO_web251003.html
@@ -445,7 +445,6 @@
             <option>P3</option>
           </select>
           <input class="input" placeholder="Rechercher travaux…" oninput="filterTable('tblOT', this.value, [5])">
-          <button class="btn" onclick="openModal('otModal')">➕ Nouvel OT</button>
         </div>
         <table aria-label="Interventions">
           <thead><tr><th>OT</th><th>Machine</th><th>Type</th><th>Priorité</th><th>Statut</th><th>Travaux</th><th>Prévu</th></tr></thead>


### PR DESCRIPTION
## Summary
- remove the "Nouvel OT" action button from the intervention tab toolbar so it no longer appears in the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13638996883308e5b29b455ee200b