### PR TITLE
Improve mobile responsiveness and navigation controls

### DIFF
--- a/GMAO_web251004.html
+++ b/GMAO_web251004.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Prototype GMAO – Modèle HTML</title>
   <style>
     :root{
@@ -48,8 +48,8 @@
       outline:2px solid var(--accent);
       outline-offset:2px;
     }
-    .app{display:grid;grid-template-columns:260px 1fr;grid-template-rows:64px 1fr;height:100vh;gap:16px;padding:16px}
-    header{grid-column:1/3;height:64px;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border:1px solid rgba(255,255,255,.06);backdrop-filter:blur(6px);border-radius:var(--radius);display:flex;align-items:center;justify-content:space-between;padding:0 16px;box-shadow:var(--shadow)}
+    .app{display:grid;grid-template-columns:minmax(200px,260px) 1fr;grid-template-rows:64px 1fr;height:100vh;gap:16px;padding:16px}
+    header{grid-column:1/-1;height:64px;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border:1px solid rgba(255,255,255,.06);backdrop-filter:blur(6px);border-radius:var(--radius);display:flex;align-items:center;justify-content:space-between;padding:0 16px;box-shadow:var(--shadow)}
     :root[data-theme="light"] header,
     :root[data-theme="light"] nav,
     :root[data-theme="light"] main{background:linear-gradient(180deg,rgba(15,23,42,.05),rgba(15,23,42,.02));border:1px solid rgba(15,23,42,.08);}
@@ -69,8 +69,13 @@
     :root[data-theme="light"] .search{background:rgba(148,163,184,.12);border:1px solid rgba(148,163,184,.28)}
     .search input{flex:1;background:transparent;border:0;outline:0;color:var(--ink)}
     .menu{margin-top:12px;display:flex;flex-direction:column;gap:6px;}
-    .menu a{padding:10px 12px;border-radius:10px;border:1px solid transparent;display:flex;gap:10px;align-items:center}
-    .menu a.active, .menu a:hover{background:rgba(167,139,250,.1);border-color:rgba(167,139,250,.25)}
+    .menu a,
+    .menu button{padding:10px 12px;border-radius:10px;border:1px solid transparent;display:flex;gap:10px;align-items:center;background:none;color:inherit;font:inherit;cursor:pointer;text-align:left}
+    .menu button{width:100%;appearance:none;-webkit-appearance:none}
+    .menu a.active,
+    .menu a:hover,
+    .menu button.active,
+    .menu button:hover{background:rgba(167,139,250,.1);border-color:rgba(167,139,250,.25)}
 
     main{background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border:1px solid rgba(255,255,255,.06);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow);overflow:auto}
     .section{display:none;}
@@ -176,7 +181,7 @@
     /* Bloc sites du tableau de bord */
     .sites-card{margin-bottom:16px}
     .site-panels{display:flex;gap:16px;flex-wrap:wrap;align-items:stretch}
-    .site-panel{flex:1 1 320px;background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:18px;padding:18px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:18px;min-width:280px}
+    .site-panel{flex:1 1 320px;background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:18px;padding:18px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:18px;min-width:260px}
     :root[data-theme="light"] .site-panel{border:1px solid rgba(15,23,42,.08)}
     .site-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
     .site-title{font-size:16px;font-weight:700;letter-spacing:.4px;text-transform:uppercase}
@@ -199,13 +204,46 @@
     .dot.info{background:var(--brand)}
     .dot.attn{background:#facc15}
 
+    @media (max-width:1200px){
+      .app{grid-template-columns:minmax(180px,220px) 1fr}
+    }
+
+    @media (max-width:900px){
+      .app{grid-template-columns:minmax(160px,200px) 1fr}
+      .menu button{font-size:13px;padding:8px 10px}
+    }
+
     @media (max-width:1100px){
-      .app{grid-template-columns:1fr;grid-template-rows:auto 1fr}
+      .kpis{grid-template-columns:repeat(2,minmax(0,1fr))}
+      .grid{grid-template-columns:1fr}
+      .site-panel{flex:1 1 260px}
+    }
+
+    @media (max-width:768px){
+      .app{grid-template-columns:1fr;grid-template-rows:auto auto 1fr;gap:12px;padding:12px;height:auto;min-height:100vh}
+      header{order:1;flex-wrap:wrap;gap:12px;padding:12px;height:auto}
       nav{order:2}
       main{order:3}
-      header{order:1}
-      .kpis{grid-template-columns:repeat(2,1fr)}
-      .grid{grid-template-columns:1fr}
+      .header-actions{width:100%;justify-content:flex-start;flex-wrap:wrap}
+      .brand h1{font-size:15px}
+      .menu{flex-direction:row;flex-wrap:wrap}
+      .menu button{flex:1 1 140px;font-size:14px}
+      .kpis{grid-template-columns:1fr}
+      .card{padding:12px}
+      .site-panels{flex-direction:column}
+      .site-panel{min-width:0}
+      .availability-value{font-size:32px}
+    }
+
+    @media (max-width:480px){
+      .brand h1{font-size:14px}
+      .btn{padding:6px 10px}
+      .menu button{flex:1 1 120px;font-size:13px;padding:8px}
+      .toolbar{flex-direction:column;align-items:stretch}
+      .toolbar .input,
+      .toolbar select{width:100%}
+      table{font-size:13px}
+      th,td{padding:8px}
     }
   </style>
 </head>
@@ -232,13 +270,13 @@
         <input id="globalSearch" placeholder="Rechercher… (machines, DI, pièces, fournisseurs, personnels)" oninput="globalFilter(this.value)">
       </div>
       <div class="menu" role="navigation">
-        <a href="#" class="active" data-target="dashboard" onclick="switchSection(event)">📊 Tableau de bord</a>
-        <a href="#" data-target="parc" onclick="switchSection(event)">🏭 Parc machines</a>
-        <a href="#" data-target="interventions" onclick="switchSection(event)">🛠️ Interventions</a>
-        <a href="#" data-target="pieces" onclick="switchSection(event)">🔩 Pièces détachées</a>
-        <a href="#" data-target="preventif" onclick="switchSection(event)">⏱️ Préventif</a>
-        <a href="#" data-target="contacts" onclick="switchSection(event)">📇 Contacts</a>
-        <a href="#" data-target="personnels" onclick="switchSection(event)">👤 Personnels</a>
+        <button type="button" class="active" data-target="dashboard" aria-pressed="true" onclick="switchSection(event)">📊 Tableau de bord</button>
+        <button type="button" data-target="parc" aria-pressed="false" onclick="switchSection(event)">🏭 Parc machines</button>
+        <button type="button" data-target="interventions" aria-pressed="false" onclick="switchSection(event)">🛠️ Interventions</button>
+        <button type="button" data-target="pieces" aria-pressed="false" onclick="switchSection(event)">🔩 Pièces détachées</button>
+        <button type="button" data-target="preventif" aria-pressed="false" onclick="switchSection(event)">⏱️ Préventif</button>
+        <button type="button" data-target="contacts" aria-pressed="false" onclick="switchSection(event)">📇 Contacts</button>
+        <button type="button" data-target="personnels" aria-pressed="false" onclick="switchSection(event)">👤 Personnels</button>
       </div>
     </nav>
 
@@ -1253,8 +1291,13 @@
 
     function switchSection(e){
       e.preventDefault();
-      const target = e.currentTarget.getAttribute('data-target');
-      document.querySelectorAll('.menu a').forEach(a=>a.classList.toggle('active', a.getAttribute('data-target')===target));
+      const trigger = e.currentTarget;
+      const target = trigger.getAttribute('data-target');
+      document.querySelectorAll('.menu [data-target]').forEach(item=>{
+        const isActive = item.getAttribute('data-target') === target;
+        item.classList.toggle('active', isActive);
+        item.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
       document.querySelectorAll('.section').forEach(s=>s.classList.remove('active'));
       document.getElementById(target).classList.add('active');
     }


### PR DESCRIPTION
## Summary
- adjust the application grid, spacing, and typography to improve responsiveness across breakpoints
- convert the sidebar navigation to buttons with aria states for reliable touch interaction
- update the viewport meta tag and add small-screen refinements for cards, KPIs, and toolbars

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68e24977fa748330beb5a694a460683b